### PR TITLE
Host the charting library ourselves instead of from Google

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,8 @@
 //= require react
 //= require react_ujs
 //= require components
+//= require Chart.bundle
+//= require chartkick
 //= require_tree .
 
 ready = function() {

--- a/app/controllers/concerns/statistics.rb
+++ b/app/controllers/concerns/statistics.rb
@@ -12,7 +12,7 @@ class Statistics < Rails::Application
   def shamehash
     none_shaming = total_debt + shameful_users.sum(:balance)
     shameful_users.inject({'Reputable users' => none_shaming.to_f / total_debt}) do |h, u|
-      h.merge({u.name => - u.balance.to_f / total_debt})
+      h.merge({u.name => - u.balance.to_f / total_debt * 100.0})
     end
   end
 
@@ -31,4 +31,3 @@ class Statistics < Rails::Application
       .take([shameful_users.count, 4].max)
   end
 end
-

--- a/app/views/pages/sign_in_page.html.haml
+++ b/app/views/pages/sign_in_page.html.haml
@@ -1,5 +1,4 @@
 %h1.columns-title Tab
-= javascript_include_tag "//www.google.com/jsapi", "chartkick"
 .pure-g.landing_columns
   .pure-u-1.pure-u-md-1-2
     %h2 Authentication
@@ -7,4 +6,4 @@
     %p= link_to "Log in met Zeus WPI", user_zeuswpi_omniauth_authorize_path, class: "pure-button pure-button-primary login-button"
   .pure-u-1.pure-u-md-1-2
     %h2 Pie of Shame
-    = pie_chart @statistics.shamehash
+    = pie_chart @statistics.shamehash, suffix: '%'


### PR DESCRIPTION
This fixes the debt chart not working in Firefox (has a built-in tracking blocker). Also made chart nicer
to display by adding percentages