### PR TITLE
Allow the issuer of a request to cancel it (closes #50)

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,11 +1,11 @@
 class RequestsController < ApplicationController
   load_and_authorize_resource :user, find_by: :name
 
-  before_action :load_request, only: [:confirm, :decline]
-  authorize_resource :request, id_param: :request_id, only: [:confirm, :decline]
+  before_action :load_request, only: [:confirm, :decline, :cancel]
+  authorize_resource :request, id_param: :request_id, only: [:confirm, :decline, :cancel]
 
   def index
-    @requests = @user.incoming_requests.group_by(&:status)
+    @requests = @user.requests.group_by(&:status)
     respond_to do |format|
       format.html { }
       format.json { render json: @requests }
@@ -19,6 +19,11 @@ class RequestsController < ApplicationController
 
   def decline
     @request.decline!
+    redirect_to root_path
+  end
+
+  def cancel
+    @request.cancel!
     redirect_to root_path
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -17,7 +17,7 @@
 class Request < ActiveRecord::Base
   include BaseTransaction
 
-  enum status: [:open, :confirmed, :declined]
+  enum status: [:open, :confirmed, :declined, :cancelled]
 
   def confirm!
     return unless open?
@@ -36,6 +36,15 @@ class Request < ActiveRecord::Base
     update_attributes status: :declined
   end
 
+  def cancel!
+    return unless open?
+
+    Notification.create user: creditor, message: cancelled_message unless issuer == creditor
+    Notification.create user: debtor, message: cancelled_message unless issuer == debtor
+
+    update_attributes status: :cancelled
+  end
+
   private
 
   def confirmed_message
@@ -44,5 +53,9 @@ class Request < ActiveRecord::Base
 
   def declined_message
     "#{debtor.name} refuses to pay €#{amount/100.0} for \"#{message}\"."
+  end
+
+  def cancelled_message
+    "#{issuer.name} cancelled the request to pay #{debtor.name} €#{amount/100.0} for \"#{message}\" to #{creditor.name}."
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,10 @@ class User < ActiveRecord::Base
     Transaction.where('creditor_id = ?', id).or(Transaction.where('debtor_id = ?', id))
   end
 
+  def requests
+    Request.where('debtor_id = ?', id).or(Request.where('creditor_id = ?', id).or(Request.where('issuer_id = ?', id)))
+  end
+
   def calculate_balance!
     balance = incoming_transactions.sum(:amount) -
                 outgoing_transactions.sum(:amount)

--- a/app/models/user_ability.rb
+++ b/app/models/user_ability.rb
@@ -7,6 +7,7 @@ class UserAbility
     can :manage, :all if user.penning?
     can :create, Request, creditor_id: user.id
     can [:confirm, :decline], Request, debtor_id: user.id
+    can :cancel, Request, issuer_id: user.id
     can [:read, :reset_key, :add_registration_token], User, id: user.id
     can :manage, Notification, user_id: user.id
     can :create, Transaction do |t|

--- a/app/views/requests/_index.html.haml
+++ b/app/views/requests/_index.html.haml
@@ -2,24 +2,34 @@
 %table.pure-table
   %thead
     %tr
-      %th Peer
       %th Issuer
+      %th Creditor
+      %th Debtor
       %th Amount
       %th Message
       - if actions
-        %th Accept
-        %th Decline
+        %th Actions
   %tbody
     - (requests || []).each do |r|
       %tr
-        %td= r.creditor.name
         %td= r.issuer.name
+        %td= r.creditor.name
+        %td= r.debtor.name
         %td= r.amount_f
         %td= r.message
         - if actions
           %td
-            = link_to request_confirm_path(r), method: :post do
-              %span.glyphicon.glyphicon-ok
-          %td
-            = link_to request_decline_path(r), method: :post do
-              %span.glyphicon.glyphicon-remove
+            - if can?(:confirm, r)
+              = link_to request_confirm_path(r), method: :post, class: "btn btn-success btn-xs" do
+                %i.glyphicon.glyphicon-ok
+                Accept
+              &nbsp;
+            - if can?(:decline, r)
+              = link_to request_decline_path(r), method: :post, class: "btn btn-danger btn-xs" do
+                %i.glyphicon.glyphicon-remove
+                Decline
+              &nbsp;
+            - if can?(:cancel, r)
+              = link_to request_cancel_path(r), method: :post, class: "btn btn-warning btn-xs" do
+                %i.glyphicon.glyphicon-trash
+                Cancel

--- a/app/views/requests/index.html.haml
+++ b/app/views/requests/index.html.haml
@@ -1,3 +1,4 @@
 = render 'index', actions: true, title: 'Open Requests', requests: @requests['open']
-= render 'index', actions: false, title: 'Confirmed Requests', requests: @requests['confirmed'] 
+= render 'index', actions: false, title: 'Confirmed Requests', requests: @requests['confirmed']
 = render 'index', actions: false, title: 'Declined Requests', requests: @requests['declined']
+= render 'index', actions: false, title: 'Cancelled Requests', requests: @requests['cancelled']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     resources :requests, only: [:index], shallow: true do
       post :confirm
       post :decline
+      post :cancel
     end
     resources :notifications, only: [:index], shallow: true do
       post :read


### PR DESCRIPTION
Also shows more information on the request page so you can track outgoing and incoming requests, and requests you've set up for other people. (Not sure if the last thing can be entered in the framework, but the backend supports it.)