### PR TITLE
Fix slow transactions json

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -2,7 +2,7 @@ class TransactionsController < ApplicationController
   load_and_authorize_resource :user, find_by: :name
 
   def index
-    @transactions = @user.transactions
+    @transactions = @user.transactions.includes(:debtor, :creditor, :issuer)
     respond_to do |format|
       format.json {
           render json: @transactions.map {|t| {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,21 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+#
+
+if Rails.env.development?
+
+  hupseflupse = User.create name: 'hupseflupse'
+
+  others = 100.times.map do |i|
+    User.create name: "user#{i}"
+  end
+
+
+  10.times do
+    others.each do |other|
+      Transaction.create message: 'ping', amount: 100, debtor: hupseflupse, creditor: other, issuer: other
+      Transaction.create message: 'pong', amount: 100, debtor: other, creditor: hupseflupse, issuer: hupseflupse
+    end
+  end
+end

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+let
+  pkgs = import <nixpkgs> { };
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    sqlite
+    libmysqlclient
+    nodejs-14_x
+    ruby_2_7
+    zlib
+    (
+      pkgs.writeShellScriptBin "start-docker" ''
+        trap "systemd-run --user --no-block docker stop tab-db" 0
+        docker run --name tab-db -p 3306:3306 --rm -v tab-db-data:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=tab -e MYSQL_DATABASE=tab -e MYSQL_USER=tab -e MYSQL_PASSWORD=tab mariadb:latest --general-log --general-log-file=/dev/stdout
+      ''
+    )
+  ];
+  shellHook = ''
+    export TEST_DATABASE_URL="mysql2://tab:tab@127.0.0.1:3306/tab_test"
+    export DATABASE_URL="mysql2://tab:tab@127.0.0.1:3306/tab"
+    export GEM_HOME="$PWD/vendor/bundle/$(ruby -e 'puts RUBY_VERSION')"
+    export PATH="$GEM_HOME/bin:$PATH"
+  '';
+}


### PR DESCRIPTION
The generated json used fields from related records (issuer, creditor and debtor) which caused a (cached) database lookup for every record, which was slowing down the request big time.

By using ActiveRecord's [`includes`](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-includes) we are able to also include the records of the users included in the query. So instead of small little db requests:
```
...
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1  [["id", 1], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:10
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 2 LIMIT 1  [["id", 2], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:11
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 2 LIMIT 1  [["id", 2], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:15
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 2 LIMIT 1  [["id", 2], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:10
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1  [["id", 1], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:11
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1  [["id", 1], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:15
  CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1  [["id", 1], ["LIMIT", 1]]
  ↳ app/controllers/transactions_controller.rb:10
...
  ```
  We now always have four (chonky) requests:
  ```
    Transaction Load (1.3ms)  SELECT `transactions`.* FROM `transactions` WHERE ((creditor_id = 1) OR (debtor_id = 1))
  ↳ app/controllers/transactions_controller.rb:8
  User Load (0.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101)
  ↳ app/controllers/transactions_controller.rb:8
  User Load (0.5ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (2, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101)
  ↳ app/controllers/transactions_controller.rb:8
  CACHE User Load (0.0ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (2, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101)
  ↳ app/controllers/transactions_controller.rb:8
  ```
This cuts down the request time to fetch 2000 transactions on my machine by a factor of 10:
**Before:**  `Completed 200 OK in 2224ms (Views: 31.2ms | ActiveRecord: 23.0ms)`
**After:** `Completed 200 OK in 207ms (Views: 94.0ms | ActiveRecord: 3.7ms)`

This PR also adds a `shell.nix` file to allow for easy development using nix. If this is not wanted, I can remove this from the PR.