### PR TITLE
Split out API controllers

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  module V1
+    class ApplicationController < ActionController::Base
+      skip_before_action :verify_authenticity_token
+
+      before_action :require_login!
+
+      def require_login!
+        return true if authenticate_user_or_client!
+        render json: { errors: [ { detail: "Access denied" } ] }, status: 401
+      end
+
+      def authenticate_user_or_client!
+        current_user_or_client
+      end
+
+      def current_user_or_client
+        current_user || current_client
+      end
+
+      def current_user
+        @current_user ||= authenticate_with_http_token do |token, _|
+          User.find_by(key: token)
+        end
+      end
+
+      def current_client
+        @current_client ||= authenticate_with_http_token do |token, _|
+          Client.find_by key: token
+        end
+      end
+
+      def current_ability
+        @current_ability ||=
+          current_client.try { |c| ClientAbility.new(c) } ||
+            UserAbility.new(current_user_or_client)
+      end
+
+      rescue_from CanCan::AccessDenied do |_|
+        render json: { errors: [ { detail: "Diefstal is een misdrijf" } ] }, status: 403
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  module V1
+    class TransactionsController < Api::V1::ApplicationController
+      load_and_authorize_resource :user, find_by: :name
+
+      def index
+        @transactions = @user.transactions.includes(:debtor, :creditor, :issuer)
+
+        render json: @transactions.map do |t|
+          {
+            id: t.id,
+            debtor: t.debtor.name,
+            creditor: t.creditor.name,
+            time: t.updated_at,
+            amount: t.amount,
+            message: t.message,
+            issuer: t.issuer.name
+          }
+        end
+      end
+
+      def create
+        @transaction = Transaction.new(transaction_params)
+        @transaction.reverse if @transaction.amount < 0
+
+        unless can? :create, @transaction
+          @transaction = Request.new @transaction.info
+          authorize!(:create, @transaction)
+        end
+
+        if @transaction.save
+          render json: @transaction, status: :created
+        else
+          render json: @transaction.errors.full_messages, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def transaction_params
+        t = params.require(:transaction).permit(:debtor, :creditor, :message, :euros, :cents, :id_at_client)
+
+        {
+          debtor: t[:debtor] ? User.find_by(name: t[:debtor]) : User.zeus,
+          creditor: t[:creditor] ? User.find_by(name: t[:creditor]) : User.zeus,
+          issuer: current_user_or_client,
+          amount: (BigDecimal(t[:euros] || 0, 2) * 100 + t[:cents].to_i).to_i,
+          message: t[:message],
+        }.merge(current_client ? { id_at_client: t[:id_at_client] } : {})
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,26 @@
+module Api
+  module V1
+    class UsersController < ApplicationController
+
+      load_resource :user, find_by: :name
+
+      def show
+        if can?(:read, @user)
+          render json: @user
+        else
+          render json: @user.to_json(only: [:id, :name])
+        end
+      end
+
+      def index
+        @users = User.all
+
+        if can?(:manage, :all)
+          render json: @users
+        else
+          render json: @users.to_json(only: [:id, :name])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   protect_from_forgery with: :exception
+
   # Don't verify authenticity token (protects against CSRF) for API requests
   skip_before_action :verify_authenticity_token, if: :api_request?
 
@@ -20,7 +21,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_client
-    @current_client ||= authenticate_with_http_token do |token, options|
+    @current_client ||= authenticate_with_http_token do |token, _|
       Client.find_by key: token
     end
   end
@@ -32,7 +33,7 @@ class ApplicationController < ActionController::Base
   end
 
   def user_token
-    @user_token ||= authenticate_with_http_token do |token, options|
+    @user_token ||= authenticate_with_http_token do |token, _|
       User.find_by key: token
     end
   end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,17 +5,18 @@ class TransactionsController < ApplicationController
     @transactions = @user.transactions.includes(:debtor, :creditor, :issuer)
     respond_to do |format|
       format.json {
-          render json: @transactions.map {|t| {
-              :id => t.id,
-              :debtor => t.debtor.name,
-              :creditor => t.creditor.name,
-              :time => t.updated_at,
-              :amount => t.amount,
-              :message => t.message,
-              :issuer => t.issuer.name
-        }
+        render json: @transactions.map do |t|
+          {
+            id: t.id,
+            debtor: t.debtor.name,
+            creditor: t.creditor.name,
+            time: t.updated_at,
+            amount: t.amount,
+            message: t.message,
+            issuer: t.issuer.name
+          }
+        end
       }
-  }
     end
   end
 
@@ -44,7 +45,7 @@ class TransactionsController < ApplicationController
       respond_to do |format|
         format.html { redirect_to root_path }
         format.json { render json: @transaction.errors.full_messages,
-        status: :unprocessable_entity }
+          status: :unprocessable_entity }
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   root to: 'pages#sign_in_page'
 
   resources :transactions, only: [:create]
-  resources :users, only: %i[index show] do
+  resources :users, only: [:index, :show] do
     resources :requests, only: [:index], shallow: true do
       post :confirm
       post :decline
@@ -28,9 +28,19 @@ Rails.application.routes.draw do
     resources :notifications, only: [:index], shallow: true do
       post :read
     end
-    resources :transactions, only: [:index], shallow: true
+    resources :transactions, only: [:index]
     post :reset_key, on: :member
     post :add_registration_token, on: :member
+  end
+
+  namespace :api, defaults: {format: :json} do
+    namespace :v1 do
+      resources :transactions, only: [:create]
+
+      resources :users, only: [:index, :show] do
+        resources :transactions, only: [:index]
+      end
+    end
   end
 
   get 'datatables/:id' => 'datatables#transactions_for_user', as: "user_transactions_datatable"

--- a/spec/controllers/api/v1/transactions_controller_spec.rb
+++ b/spec/controllers/api/v1/transactions_controller_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Api::V1::TransactionsController, type: :request do
+  describe "api" do
+
+    let(:debtor) { create :user }
+    let(:creditor) { create :user }
+    let(:api_attributes) {
+      {
+        debtor: debtor.name,
+        creditor: creditor.name,
+        message: Faker::Lorem.sentence,
+        euros: 1,
+        cents: 25,
+        id_at_client: 1
+      }
+    }
+    let(:client) { create :client, name: 'Tap' }
+    let(:key) { client.key }
+
+    def post_transaction(extra_attributes = {})
+      post(
+        '/transactions',
+        params: { transaction: api_attributes.merge(extra_attributes) },
+        headers: { 'HTTP_ACCEPT' => "application/json", "HTTP_AUTHORIZATION" => "Token token=#{key}" }
+      )
+    end
+
+    describe 'with key' do
+      before do
+        client.add_role(:create_transactions)
+      end
+
+      describe "Authentication" do
+        it "should require a client authentication key" do
+          post '/transactions'
+          expect(response.status).to eq(302)
+        end
+
+        it "should work with valid key" do
+          post_transaction
+          expect(response.status).to eq(201)
+        end
+      end
+
+      describe "successful creating transaction" do
+        it "should create a transaction" do
+          expect { post_transaction }.to change { Transaction.count }.by(1)
+        end
+
+        it "should handles floats properly" do
+          expect { post_transaction(euros: 9.70, cents: 0) }.to change { Transaction.count }.by(1)
+
+          transaction = Transaction.last
+
+          expect(transaction.amount).to eq(970)
+        end
+
+        it "should set issuer" do
+          post_transaction
+
+          transaction = Transaction.last
+          expect(transaction.issuer).to eq(client)
+        end
+      end
+
+      describe "failed creating transaction" do
+        # it "should create a transaction" do
+        # expect { post_transaction(euros: -5) }.to change { Transaction.count }.by(0)
+        # end
+
+        # it "should give 422 status" do
+        # post_transaction(euros: -4)
+        # expect(last_response.status).to eq(422)
+        # end
+      end
+    end
+
+    describe 'without key' do
+      it "should not create a transaction" do
+        expect { post_transaction }.not_to(change { Transaction.count })
+      end
+    end
+  end
+end

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe RequestsController, type: :controller do
   describe 'accepting request' do

--- a/spec/controllers/transactions_controller_spec.rb
+++ b/spec/controllers/transactions_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "rails_helper"
 
 RSpec.describe TransactionsController, type: :controller do
   describe "creating transaction" do
@@ -77,8 +78,8 @@ RSpec.describe TransactionsController, type: :controller do
             debtor: debtor.name,
             creditor: creditor.name,
             euros: 100000000000000,
-          message: "VEEL GELD"
-        }})
+            message: "VEEL GELD"
+          }})
         end.not_to(change { Transaction.count })
       end
     end
@@ -106,90 +107,6 @@ RSpec.describe TransactionsController, type: :controller do
             message: "Debts"
           }})
         end.not_to(change { Transaction.count })
-      end
-    end
-  end
-end
-
-RSpec.describe TransactionsController, type: :request do
-  describe "api" do
-
-    let(:debtor) { create :user }
-    let(:creditor) { create :user }
-    let(:api_attributes) {
-      {
-        debtor: debtor.name,
-        creditor: creditor.name,
-        message: Faker::Lorem.sentence,
-        euros: 1,
-        cents: 25,
-        id_at_client: 1
-      }
-    }
-    let(:client) { create :client, name: 'Tap' }
-    let(:key) { client.key }
-
-    def post_transaction(extra_attributes = {})
-      post(
-        '/transactions',
-        params: { transaction: api_attributes.merge(extra_attributes) },
-        headers: { 'HTTP_ACCEPT' => "application/json", "HTTP_AUTHORIZATION" => "Token token=#{key}" }
-      )
-    end
-
-    describe 'with key' do
-      before do
-        client.add_role(:create_transactions)
-      end
-
-      describe "Authentication" do
-        it "should require a client authentication key" do
-          post '/transactions'
-          expect(response.status).to eq(302)
-        end
-
-        it "should work with valid key" do
-          post_transaction
-          expect(response.status).to eq(201)
-        end
-      end
-
-      describe "successful creating transaction" do
-        it "should create a transaction" do
-          expect { post_transaction }.to change { Transaction.count }.by(1)
-        end
-
-        it "should handles floats properly" do
-          expect { post_transaction(euros: 9.70, cents: 0) }.to change { Transaction.count }.by(1)
-
-          transaction = Transaction.last
-
-          expect(transaction.amount).to eq(970)
-        end
-
-        it "should set issuer" do
-          post_transaction
-
-          transaction = Transaction.last
-          expect(transaction.issuer).to eq(client)
-        end
-      end
-
-      describe "failed creating transaction" do
-        # it "should create a transaction" do
-        # expect { post_transaction(euros: -5) }.to change { Transaction.count }.by(0)
-        # end
-
-        # it "should give 422 status" do
-        # post_transaction(euros: -4)
-        # expect(last_response.status).to eq(422)
-        # end
-      end
-    end
-
-    describe 'without key' do
-      it "should not create a transaction" do
-        expect { post_transaction }.not_to(change { Transaction.count })
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
   before :each do


### PR DESCRIPTION
PR to split out API controllers. Currently pointing at the Rails 7 #86 branch. 

Methods will be removed from the "normal" controllers after a deprecation time when merged.