### PR TITLE
Minimize javascript on production, add esbuild.config.js

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: bin/rails server -p 3000
-js: yarn build --watch
+js: yarn build:dev --watch
 css: yarn build:css --watch

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const esBuild = require('esbuild')
+
+const watch = process.argv.includes('--watch')
+const minify = process.argv.includes('--minify')
+
+const watchOptions = {
+  onRebuild: (error, result) => {
+    if (error) {
+      console.error('watch build failed:', error)
+    } else {
+      console.log(result)
+      console.log('watch build succeeded. ')
+    }
+  }
+}
+
+const loaders = {
+  '.js': 'jsx'
+}
+
+esBuild.build({
+  entryPoints: ['app/javascript/application.js'],
+  logLevel: 'info',
+  bundle: true,
+  outdir: 'app/assets/builds',
+  watch: watch && watchOptions,
+  sourcemap: 'linked',
+  loader: loaders,
+  publicPath: '/assets',
+  minify
+}).then(result => {
+  console.log(result)
+  if (watch) {
+    console.log('Build finished, watching for changes...')
+  } else {
+    console.log('Build finished, Congrats')
+  }
+}).catch(result => {
+  console.log(result)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "tom-select": "^2.0.3"
   },
   "scripts": {
-    "build": "esbuild app/javascript/application.js --bundle --sourcemap --outdir=app/assets/builds --loader:.js=jsx",
+    "build": "node esbuild.config.js --minify",
+    "build:dev": "node esbuild.config.js",
     "build:css": "tailwindcss --postcss --verbose -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #108 

Adds a specific `build:dev` task running from the `Procfile.dev` as the `jsbundling` gem just runs `yarn build` without support to pass additional info/settings.