### PR TITLE
Introduce fuse.js for better searching through users

### DIFF
--- a/app/javascript/react/src/components/TransactionForm.jsx
+++ b/app/javascript/react/src/components/TransactionForm.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Select from 'react-select';
+import Fuse from 'fuse.js';
 
 const url = function (path) {
   return (window.base_url || '') + "/" + path;
@@ -96,10 +97,36 @@ class Amount extends React.Component {
 }
 
 class Peer extends React.Component {
-  options() {
+  constructor(props) {
+    super(props);
+
     const { peers } = this.props;
 
+    const peerOptions = this.toOptions(peers);
+
+    const fuse = new Fuse(peerOptions, { keys: ["label"] });
+
+    this.state = {
+      options: peerOptions,
+      fuse: fuse
+    }
+  }
+
+  toOptions(peers) {
     return peers.map(p => ({value: p, label: p}));
+  }
+
+  setOptions(options) {
+    this.setState({
+      options: options
+    });
+  }
+
+  onInputChange(inputValue) {
+    const { fuse } = this.state;
+    const { peers } = this.props;
+
+    this.setOptions(!!inputValue ? fuse.search(inputValue).map(value => value.item) : this.toOptions(peers));
   }
 
   setPeer(appel) {
@@ -107,7 +134,7 @@ class Peer extends React.Component {
   }
 
   render() {
-    const options = this.options();
+    const { options } = this.state;
     const { peer } = this.props;
     const peerOption = options.find(o => o.value === peer)
 
@@ -117,6 +144,7 @@ class Peer extends React.Component {
           value={peerOption}
           onChange={(e) => this.setPeer(e)}
           options={options}
+          onInputChange={inputValue => this.onInputChange(inputValue)}
           menuPortalTarget={document.body}
           menuPosition={'fixed'}
           className={'text-sm w-2/3 border-gray-200 text-gray-900 focus:ring-blue-500 focus:border-blue-500 z-20'}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "datatables": "^1.10.18",
     "datatables.net": "^1.12.1",
     "esbuild": "^0.14.39",
+    "fuse.js": "^6.6.2",
     "luxon": "^2.4.0",
     "postcss": "^8.4.14",
     "react": "^18.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,6 +631,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+fuse.js@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
+  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"


### PR DESCRIPTION
Closes #126

Introduces [Fuse.js](https://fusejs.io/) as a fuzzy search library.

Added for the sole purpose of finding @redfast00 easier in the list:

A list with several people with a `j` in their name:

![image](https://user-images.githubusercontent.com/915130/173231049-1cea1940-cbac-4bfa-bee8-b2449e1dd42b.png)

Will now list `j` as first match when looking for `j`:

![image](https://user-images.githubusercontent.com/915130/173231058-ded0c922-7493-4d23-8802-d878e19c642b.png)

Fuse.js can do heaps more to make the search fuzzier, so might be tuned later on if needed.