### PR TITLE
feat(transactions): added pagination to transactions

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -6,12 +6,11 @@ module Api
       load_and_authorize_resource :user, find_by: :name
 
       def index
-        query = @user.transactions
-
-        query = query.limit(params[:limit]) if params.include?(:limit)
-        query = query.offset(params[:start]) if params.include?(:start)
-
-        transactions = query.includes(:debtor, :creditor, :issuer)
+        transactions = @user.transactions
+                            .order("updated_at desc")
+                            .offset(params[:start])
+                            .limit(params[:limit])
+                            .includes(:debtor, :creditor, :issuer)
 
         mapped_transactions = transactions.map do |t|
           {

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -6,7 +6,12 @@ module Api
       load_and_authorize_resource :user, find_by: :name
 
       def index
-        transactions = @user.transactions.includes(:debtor, :creditor, :issuer)
+        query = @user.transactions
+
+        query = query.limit(params[:limit]) if params.include?(:limit)
+        query = query.offset(params[:start]) if params.include?(:start)
+
+        transactions = query.includes(:debtor, :creditor, :issuer)
 
         mapped_transactions = transactions.map do |t|
           {


### PR DESCRIPTION
First time writing in this language so I'm open for criticism.

Adds the `limit=` and `start=` query parameters to the `/api/v1/users/USERNAME/transactions` endpoint.

closes #114 